### PR TITLE
GIFEncoder: clarify delay comment

### DIFF
--- a/lib/GIFEncoder.js
+++ b/lib/GIFEncoder.js
@@ -130,7 +130,7 @@ GIFEncoder.prototype.end = function() {
 
 /*
   Sets the delay time between each frame, or changes it for subsequent frames
-  (applies to last frame added)
+  (applies to the next frame added)
 */
 GIFEncoder.prototype.setDelay = function(milliseconds) {
   this.delay = Math.round(milliseconds / 10);


### PR DESCRIPTION
By reading the code it seems setting the delay has effect on the next added frame, so I changed the comment to reflect that a bit more accurately.