### PR TITLE
Fix setting transparent color

### DIFF
--- a/lib/GIFEncoder.js
+++ b/lib/GIFEncoder.js
@@ -292,16 +292,15 @@ GIFEncoder.prototype.findClosest = function(c) {
   var len = this.colorTab.length;
 
   for (var i = 0; i < len;) {
+    var index = i / 3;
     var dr = r - (this.colorTab[i++] & 0xff);
     var dg = g - (this.colorTab[i++] & 0xff);
-    var db = b - (this.colorTab[i] & 0xff);
+    var db = b - (this.colorTab[i++] & 0xff);
     var d = dr * dr + dg * dg + db * db;
-    var index = i / 3;
     if (this.usedEntry[index] && (d < dmin)) {
       dmin = d;
       minpos = index;
     }
-    i++;
   }
 
   return minpos;

--- a/lib/GIFEncoder.js
+++ b/lib/GIFEncoder.js
@@ -275,6 +275,13 @@ GIFEncoder.prototype.analyzePixels = function() {
   // get closest match to transparent color if specified
   if (this.transparent !== null) {
     this.transIndex = this.findClosest(this.transparent);
+
+    // ensure that pixels with full transparency in the RGBA image are using the selected transparent color index in the indexed image.
+    for (var pixelIndex = 0; pixelIndex < nPix; pixelIndex++) {
+      if (this.image[pixelIndex * 4 + 3] == 0) {
+        this.indexedPixels[pixelIndex] = this.transIndex;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Index calculation findClosest() produced fractional indices to this.usedEntry[], fixed that.
