### PR TITLE
Fix a bug with transparent background for animated GIF

### DIFF
--- a/lib/GIFEncoder.js
+++ b/lib/GIFEncoder.js
@@ -249,6 +249,7 @@ GIFEncoder.prototype.start = function() {
 GIFEncoder.prototype.analyzePixels = function() {
   var len = this.pixels.length;
   var nPix = len / 3;
+  var usedEntry = [];
 
   this.indexedPixels = new Uint8Array(nPix);
 
@@ -299,7 +300,7 @@ GIFEncoder.prototype.findClosest = function(c) {
   var len = this.colorTab.length;
 
   for (var i = 0; i < len;) {
-    var index = i / 3;
+    var index = (i + 1) / 3;
     var dr = r - (this.colorTab[i++] & 0xff);
     var dg = g - (this.colorTab[i++] & 0xff);
     var db = b - (this.colorTab[i++] & 0xff);

--- a/lib/GIFEncoder.js
+++ b/lib/GIFEncoder.js
@@ -249,7 +249,7 @@ GIFEncoder.prototype.start = function() {
 GIFEncoder.prototype.analyzePixels = function() {
   var len = this.pixels.length;
   var nPix = len / 3;
-  var usedEntry = [];
+  this.usedEntry = [];
 
   this.indexedPixels = new Uint8Array(nPix);
 


### PR DESCRIPTION
Source: https://stackoverflow.com/questions/73647646/cannot-make-transparent-background-when-saving-canvas-to-gif