### PR TITLE
Update LZWEncoder.js, fix for ESM

### DIFF
--- a/lib/LZWEncoder.js
+++ b/lib/LZWEncoder.js
@@ -26,6 +26,7 @@ var HSIZE = 5003; // 80% occupancy
 var masks = [0x0000, 0x0001, 0x0003, 0x0007, 0x000F, 0x001F,
              0x003F, 0x007F, 0x00FF, 0x01FF, 0x03FF, 0x07FF,
              0x0FFF, 0x1FFF, 0x3FFF, 0x7FFF, 0xFFFF];
+var remaining, curPixel, n_bits;
 
 function LZWEncoder(width, height, pixels, colorDepth) {
   var initCodeSize = Math.max(2, colorDepth);


### PR DESCRIPTION
I just need to run it under the storybook.

I got this error:

`ReferenceError: remaining is not defined
    at LZWEncoder.encode (LZWEncoder.js:141:1)
    at __webpack_modules__.../../node_modules/gifencoder/lib/GIFEncoder.js.GIFEncoder.writePixels (GIFEncoder.js:453:1)
    at __webpack_modules__.../../node_modules/gifencoder/lib/GIFEncoder.js.GIFEncoder.addFrame (GIFEncoder.js:210:1)
    at to_giff.ts:40:21
    at Generator.next (<anonymous>)`